### PR TITLE
server_max_value_length

### DIFF
--- a/memcache/bottle_memcache.py
+++ b/memcache/bottle_memcache.py
@@ -12,10 +12,11 @@ class MemcachePlugin(object):
 
     name = 'memcache'
 
-    def __init__(self, servers=['localhost:11211', ], keyword='mc'):
+    def __init__(self, servers=['localhost:11211', ], keyword='mc', server_max_value_length=memcache.SERVER_MAX_VALUE_LENGTH):
 
         self.servers = servers
         self.keyword = keyword
+        self.server_max_value_length = server_max_value_length
 
     def setup(self, app):
         for other in app.plugins:
@@ -28,13 +29,14 @@ class MemcachePlugin(object):
         conf = context['config'].get('memcache') or {}
         servers = conf.get('servers', self.servers)
         keyword = conf.get('keyword', self.keyword)
+        server_max_value_length = conf.get('server_max_value_length', self.server_max_value_length)
 
         args = inspect.getargspec(context['callback'])[0]
         if keyword not in args:
             return callback
 
         def wrapper(*args,**kwargs):
-            mc = memcache.Client(servers=self.servers, debug=0)
+            mc = memcache.Client(servers=self.servers, server_max_value_length=self.server_max_value_length, debug=0)
             kwargs[self.keyword] = mc
             rv = callback(*args, **kwargs)
             return rv


### PR DESCRIPTION
Hello,

Since memcached 1.4.2 the server allows the modification of the default item size limit (1 MB). However, python-memcache doesn't even send items that are bigger than server_max_value_length (which may be specified in the **init** of the Client object).

I just need this feature for a project and thought that it could be interesting for you.

Cheers,
J.
