### PR TITLE
Add missing import in memcache README example

### DIFF
--- a/memcache/README
+++ b/memcache/README
@@ -32,6 +32,7 @@ Once installed to an application, the plugin passes an open
 ``mc`` keyword argument::
 
     import bottle
+    import bottle.ext.memcache
 
     app = bottle.Bottle()
     plugin = bottle.ext.memcache.MemcachePlugin(servers=['localhost:11211'])


### PR DESCRIPTION
The example in the README does not work unless bottle.ext.memcache is explicitly imported.
